### PR TITLE
Create a Variant class that manages data

### DIFF
--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Obscure VCF vcf lines with weird info field and missing format/genotypes 1`] = `
 Array [
-  Variant {
+  Object {
     "ALT": Array [
       "A",
     ],
@@ -27,7 +27,7 @@ Array [
     "QUAL": 29,
     "REF": "R",
   },
-  Variant {
+  Object {
     "ALT": Array [
       "G",
     ],
@@ -52,7 +52,7 @@ Array [
     "QUAL": 29,
     "REF": "R",
   },
-  Variant {
+  Object {
     "ALT": Array [
       "T",
     ],
@@ -77,7 +77,7 @@ Array [
     "QUAL": 29,
     "REF": "W",
   },
-  Variant {
+  Object {
     "ALT": Array [
       "A",
     ],
@@ -102,7 +102,7 @@ Array [
     "QUAL": 29,
     "REF": "R",
   },
-  Variant {
+  Object {
     "ALT": Array [
       "G",
     ],
@@ -127,7 +127,7 @@ Array [
     "QUAL": 29,
     "REF": "R",
   },
-  Variant {
+  Object {
     "ALT": Array [
       "G",
     ],
@@ -156,11 +156,18 @@ Array [
 `;
 
 exports[`VCF parser can decode percent-encoded INFO and FORMAT fields 1`] = `
-Variant {
+Object {
   "ALT": Array [
     "A",
   ],
   "CHROM": "20",
+  "FIELDS": Array [
+    "GT",
+    "GQ",
+    "DP",
+    "HQ",
+    "TEST",
+  ],
   "FILTER": "PASS",
   "ID": Array [
     "rs6054257",
@@ -184,6 +191,58 @@ Variant {
   "POS": 14370,
   "QUAL": 29,
   "REF": "G",
+  "SAMPLES": Object {
+    "NA00001": Object {
+      "DP": Array [
+        1,
+      ],
+      "GQ": Array [
+        48,
+      ],
+      "GT": Array [
+        "0|0",
+      ],
+      "HQ": Array [
+        51,
+        51,
+      ],
+      "TEST": Array [
+        "2+2=4",
+      ],
+    },
+    "NA00002": Object {
+      "DP": Array [
+        8,
+      ],
+      "GQ": Array [
+        48,
+      ],
+      "GT": Array [
+        "1|0",
+      ],
+      "HQ": Array [
+        51,
+        51,
+      ],
+      "TEST": null,
+    },
+    "NA00003": Object {
+      "DP": Array [
+        5,
+      ],
+      "GQ": Array [
+        43,
+      ],
+      "GT": Array [
+        "1/1",
+      ],
+      "HQ": Array [
+        null,
+        null,
+      ],
+      "TEST": null,
+    },
+  },
 }
 `;
 
@@ -243,11 +302,18 @@ Object {
 `;
 
 exports[`VCF parser can decode percent-encoded INFO and FORMAT fields 3`] = `
-Variant {
+Object {
   "ALT": Array [
     "A",
   ],
   "CHROM": "20",
+  "FIELDS": Array [
+    "GT",
+    "GQ",
+    "DP",
+    "HQ",
+    "TEST",
+  ],
   "FILTER": "PASS",
   "ID": Array [
     "rs6054257",
@@ -262,6 +328,58 @@ Variant {
   "POS": 14370,
   "QUAL": 29,
   "REF": "G",
+  "SAMPLES": Object {
+    "NA00001": Object {
+      "DP": Array [
+        1,
+      ],
+      "GQ": Array [
+        48,
+      ],
+      "GT": Array [
+        "0|0",
+      ],
+      "HQ": Array [
+        51,
+        51,
+      ],
+      "TEST": Array [
+        "2+2=4",
+      ],
+    },
+    "NA00002": Object {
+      "DP": Array [
+        8,
+      ],
+      "GQ": Array [
+        48,
+      ],
+      "GT": Array [
+        "1|0",
+      ],
+      "HQ": Array [
+        51,
+        51,
+      ],
+      "TEST": null,
+    },
+    "NA00003": Object {
+      "DP": Array [
+        5,
+      ],
+      "GQ": Array [
+        43,
+      ],
+      "GT": Array [
+        "1/1",
+      ],
+      "HQ": Array [
+        null,
+        null,
+      ],
+      "TEST": null,
+    },
+  },
 }
 `;
 
@@ -901,11 +1019,17 @@ Object {
 `;
 
 exports[`VCF parser can parse a line from the VCF spec 1`] = `
-Variant {
+Object {
   "ALT": Array [
     "A",
   ],
   "CHROM": "20",
+  "FIELDS": Array [
+    "GT",
+    "GQ",
+    "DP",
+    "HQ",
+  ],
   "FILTER": "PASS",
   "ID": Array [
     "rs6054257",
@@ -926,6 +1050,53 @@ Variant {
   "POS": 14370,
   "QUAL": 29,
   "REF": "G",
+  "SAMPLES": Object {
+    "NA00001": Object {
+      "DP": Array [
+        1,
+      ],
+      "GQ": Array [
+        48,
+      ],
+      "GT": Array [
+        "0|0",
+      ],
+      "HQ": Array [
+        51,
+        51,
+      ],
+    },
+    "NA00002": Object {
+      "DP": Array [
+        8,
+      ],
+      "GQ": Array [
+        48,
+      ],
+      "GT": Array [
+        "1|0",
+      ],
+      "HQ": Array [
+        51,
+        51,
+      ],
+    },
+    "NA00003": Object {
+      "DP": Array [
+        5,
+      ],
+      "GQ": Array [
+        43,
+      ],
+      "GT": Array [
+        "1/1",
+      ],
+      "HQ": Array [
+        null,
+        null,
+      ],
+    },
+  },
 }
 `;
 
@@ -980,17 +1151,43 @@ Object {
 `;
 
 exports[`VCF parser can parse a line with minimal entries 1`] = `
-Variant {
+Object {
   "ALT": Array [
     "A",
   ],
   "CHROM": "20",
+  "FIELDS": Array [
+    "GT",
+    "GQ",
+    "DP",
+    "HQ",
+  ],
   "FILTER": null,
   "ID": null,
   "INFO": Object {},
   "POS": 14370,
   "QUAL": null,
   "REF": "G",
+  "SAMPLES": Object {
+    "NA00001": Object {
+      "DP": null,
+      "GQ": null,
+      "GT": null,
+      "HQ": null,
+    },
+    "NA00002": Object {
+      "DP": null,
+      "GQ": null,
+      "GT": null,
+      "HQ": null,
+    },
+    "NA00003": Object {
+      "DP": null,
+      "GQ": null,
+      "GT": null,
+      "HQ": null,
+    },
+  },
 }
 `;
 
@@ -1018,11 +1215,21 @@ Object {
 `;
 
 exports[`VCF parser for Y chrom (haploid) can parse a line from the VCF spec 1`] = `
-Variant {
+Object {
   "ALT": Array [
     "<CN0>",
   ],
   "CHROM": "Y",
+  "FIELDS": Array [
+    "GT",
+    "CN",
+    "CNL",
+    "CNP",
+    "CNQ",
+    "GP",
+    "GQ",
+    "PL",
+  ],
   "FILTER": "PASS",
   "ID": Array [
     "CNV_Y_14483990_15232198",
@@ -1069,6 +1276,92 @@ Variant {
   "POS": 14483990,
   "QUAL": 100,
   "REF": "C",
+  "SAMPLES": Object {
+    "HG00096": Object {
+      "CN": Array [
+        1,
+      ],
+      "CNL": Array [
+        -1000,
+        0,
+        -119.08,
+      ],
+      "CNP": Array [
+        -1000,
+        0,
+        -218.16,
+      ],
+      "CNQ": Array [
+        99,
+      ],
+      "GP": Array [
+        0,
+        -1000,
+      ],
+      "GQ": Array [
+        99,
+      ],
+      "GT": Array [
+        "0",
+      ],
+      "PL": Array [
+        0,
+        10000,
+      ],
+    },
+    "HG00101": Object {
+      "CN": Array [
+        1,
+      ],
+      "CNL": Array [
+        -1000,
+        0,
+        -43.56,
+      ],
+      "CNP": Array [
+        -1000,
+        0,
+        -142.64,
+      ],
+      "CNQ": Array [
+        99,
+      ],
+      "GP": Array [
+        0,
+        -1000,
+      ],
+      "GQ": Array [
+        99,
+      ],
+      "GT": Array [
+        "0",
+      ],
+      "PL": Array [
+        0,
+        10000,
+      ],
+    },
+    "HG00103": Object {
+      "CN": null,
+      "CNL": null,
+      "CNP": null,
+      "CNQ": null,
+      "GP": null,
+      "GQ": null,
+      "GT": null,
+      "PL": null,
+    },
+    "HG001055": Object {
+      "CN": null,
+      "CNL": null,
+      "CNP": null,
+      "CNQ": null,
+      "GP": null,
+      "GQ": null,
+      "GT": null,
+      "PL": null,
+    },
+  },
 }
 `;
 
@@ -1162,11 +1455,14 @@ Object {
 `;
 
 exports[`VCF parser for Y chrom (haploid) can parse a line from the VCF spec 3`] = `
-Variant {
+Object {
   "ALT": Array [
     "A",
   ],
   "CHROM": "Y",
+  "FIELDS": Array [
+    "GT",
+  ],
   "FILTER": "PASS",
   "ID": Array [
     "rs11575897",
@@ -1213,6 +1509,26 @@ Variant {
   "POS": 2655180,
   "QUAL": 100,
   "REF": "G",
+  "SAMPLES": Object {
+    "HG00096": Object {
+      "GT": Array [
+        "0",
+      ],
+    },
+    "HG00101": Object {
+      "GT": Array [
+        "0",
+      ],
+    },
+    "HG00103": Object {
+      "GT": Array [
+        "0",
+      ],
+    },
+    "HG001055": Object {
+      "GT": null,
+    },
+  },
 }
 `;
 
@@ -1240,11 +1556,16 @@ Object {
 `;
 
 exports[`VCF parser for structural variants can parse a line from the VCF spec 1`] = `
-Variant {
+Object {
   "ALT": Array [
     "<DEL>",
   ],
   "CHROM": "8",
+  "FIELDS": Array [
+    "GT",
+    "DR",
+    "DV",
+  ],
   "FILTER": "PASS",
   "ID": Array [
     "28329_0",
@@ -1300,6 +1621,19 @@ Variant {
   "POS": 17709115,
   "QUAL": null,
   "REF": "N",
+  "SAMPLES": Object {
+    "/seq/schatz/fritz/sv-paper/real/Nanopore_NA12878/mapped/ngm_Nanopore_human_ngmlr-0.2.3_mapped.bam": Object {
+      "DR": Array [
+        1,
+      ],
+      "DV": Array [
+        34,
+      ],
+      "GT": Array [
+        "1/1",
+      ],
+    },
+  },
 }
 `;
 
@@ -1320,7 +1654,7 @@ Object {
 `;
 
 exports[`VCF parser parses a line with a breakend ALT 1`] = `
-Variant {
+Object {
   "ALT": Array [
     Breakend {
       "Join": "right",
@@ -1346,7 +1680,7 @@ Variant {
 `;
 
 exports[`VCF parser parses a line with mix of multiple breakends and non breakends 1`] = `
-Variant {
+Object {
   "ALT": Array [
     "CTATGTCG",
     Breakend {
@@ -1384,7 +1718,7 @@ Variant {
 
 exports[`can parse breakends 1`] = `
 Array [
-  Variant {
+  Object {
     "ALT": Array [
       Breakend {
         "Join": "right",
@@ -1394,6 +1728,10 @@ Array [
       },
     ],
     "CHROM": "11",
+    "FIELDS": Array [
+      "PR",
+      "SR",
+    ],
     "FILTER": "PASS",
     "ID": Array [
       "MantaBND:0:2:3:0:0:0:1",
@@ -1425,12 +1763,27 @@ Array [
     "POS": 94975747,
     "QUAL": null,
     "REF": "G",
+    "SAMPLES": Object {
+      "BAMs/caudaus.sorted.sam": Object {
+        "PR": Array [
+          "722",
+          "9",
+        ],
+        "SR": Array [
+          "463",
+          "15",
+        ],
+      },
+    },
   },
-  Variant {
+  Object {
     "ALT": Array [
       "<DEL>",
     ],
     "CHROM": "11",
+    "FIELDS": Array [
+      "PR",
+    ],
     "FILTER": "PASS",
     "ID": Array [
       "MantaDEL:0:1:2:0:0:0",
@@ -1458,8 +1811,16 @@ Array [
     "POS": 94975753,
     "QUAL": null,
     "REF": "T",
+    "SAMPLES": Object {
+      "BAMs/caudaus.sorted.sam": Object {
+        "PR": Array [
+          "161",
+          "13",
+        ],
+      },
+    },
   },
-  Variant {
+  Object {
     "ALT": Array [
       Breakend {
         "Join": "right",
@@ -1469,6 +1830,10 @@ Array [
       },
     ],
     "CHROM": "11",
+    "FIELDS": Array [
+      "PR",
+      "SR",
+    ],
     "FILTER": "PASS",
     "ID": Array [
       "MantaBND:0:0:1:0:0:0:0",
@@ -1490,6 +1855,18 @@ Array [
     "POS": 94987872,
     "QUAL": null,
     "REF": "T",
+    "SAMPLES": Object {
+      "BAMs/caudaus.sorted.sam": Object {
+        "PR": Array [
+          "489",
+          "4",
+        ],
+        "SR": Array [
+          "520",
+          "19",
+        ],
+      },
+    },
   },
 ]
 `;
@@ -1521,6 +1898,9 @@ Array [
       "A",
     ],
     "CHROM": "Y",
+    "FIELDS": Array [
+      "GT",
+    ],
     "FILTER": "PASS",
     "ID": Array [
       "rs11575897",
@@ -1573,6 +1953,9 @@ Array [
       "C",
     ],
     "CHROM": "Y",
+    "FIELDS": Array [
+      "GT",
+    ],
     "FILTER": "PASS",
     "ID": null,
     "INFO": Object {
@@ -1623,11 +2006,17 @@ Array [
 
 exports[`snippet from VCF 4.3 spec 1`] = `
 Array [
-  Variant {
+  Object {
     "ALT": Array [
       "A",
     ],
     "CHROM": "20",
+    "FIELDS": Array [
+      "GT",
+      "GQ",
+      "DP",
+      "HQ",
+    ],
     "FILTER": "PASS",
     "ID": Array [
       "rs6054257",
@@ -1648,12 +2037,65 @@ Array [
     "POS": 14370,
     "QUAL": 29,
     "REF": "G",
+    "SAMPLES": Object {
+      "NA00001": Object {
+        "DP": Array [
+          1,
+        ],
+        "GQ": Array [
+          48,
+        ],
+        "GT": Array [
+          "0|0",
+        ],
+        "HQ": Array [
+          51,
+          51,
+        ],
+      },
+      "NA00002": Object {
+        "DP": Array [
+          8,
+        ],
+        "GQ": Array [
+          48,
+        ],
+        "GT": Array [
+          "1|0",
+        ],
+        "HQ": Array [
+          51,
+          51,
+        ],
+      },
+      "NA00003": Object {
+        "DP": Array [
+          5,
+        ],
+        "GQ": Array [
+          43,
+        ],
+        "GT": Array [
+          "1/1",
+        ],
+        "HQ": Array [
+          null,
+          null,
+        ],
+      },
+    },
   },
-  Variant {
+  Object {
     "ALT": Array [
       "A",
     ],
     "CHROM": "20",
+    "FIELDS": Array [
+      "GT",
+      "GQ",
+      "DP",
+      "HQ",
+    ],
     "FILTER": Array [
       "q10",
     ],
@@ -1672,13 +2114,63 @@ Array [
     "POS": 17330,
     "QUAL": 3,
     "REF": "T",
+    "SAMPLES": Object {
+      "NA00001": Object {
+        "DP": Array [
+          3,
+        ],
+        "GQ": Array [
+          49,
+        ],
+        "GT": Array [
+          "0|0",
+        ],
+        "HQ": Array [
+          58,
+          50,
+        ],
+      },
+      "NA00002": Object {
+        "DP": Array [
+          5,
+        ],
+        "GQ": Array [
+          3,
+        ],
+        "GT": Array [
+          "0|1",
+        ],
+        "HQ": Array [
+          65,
+          3,
+        ],
+      },
+      "NA00003": Object {
+        "DP": Array [
+          3,
+        ],
+        "GQ": Array [
+          41,
+        ],
+        "GT": Array [
+          "0/0",
+        ],
+        "HQ": null,
+      },
+    },
   },
-  Variant {
+  Object {
     "ALT": Array [
       "G",
       "T",
     ],
     "CHROM": "20",
+    "FIELDS": Array [
+      "GT",
+      "GQ",
+      "DP",
+      "HQ",
+    ],
     "FILTER": "PASS",
     "ID": Array [
       "rs6040355",
@@ -1702,10 +2194,60 @@ Array [
     "POS": 1110696,
     "QUAL": 67,
     "REF": "A",
+    "SAMPLES": Object {
+      "NA00001": Object {
+        "DP": Array [
+          6,
+        ],
+        "GQ": Array [
+          21,
+        ],
+        "GT": Array [
+          "1|2",
+        ],
+        "HQ": Array [
+          23,
+          27,
+        ],
+      },
+      "NA00002": Object {
+        "DP": Array [
+          0,
+        ],
+        "GQ": Array [
+          2,
+        ],
+        "GT": Array [
+          "2|1",
+        ],
+        "HQ": Array [
+          18,
+          2,
+        ],
+      },
+      "NA00003": Object {
+        "DP": Array [
+          4,
+        ],
+        "GQ": Array [
+          35,
+        ],
+        "GT": Array [
+          "2/2",
+        ],
+        "HQ": null,
+      },
+    },
   },
-  Variant {
+  Object {
     "ALT": null,
     "CHROM": "20",
+    "FIELDS": Array [
+      "GT",
+      "GQ",
+      "DP",
+      "HQ",
+    ],
     "FILTER": "PASS",
     "ID": null,
     "INFO": Object {
@@ -1722,13 +2264,62 @@ Array [
     "POS": 1230237,
     "QUAL": 47,
     "REF": "T",
+    "SAMPLES": Object {
+      "NA00001": Object {
+        "DP": Array [
+          7,
+        ],
+        "GQ": Array [
+          54,
+        ],
+        "GT": Array [
+          "0|0",
+        ],
+        "HQ": Array [
+          56,
+          60,
+        ],
+      },
+      "NA00002": Object {
+        "DP": Array [
+          4,
+        ],
+        "GQ": Array [
+          48,
+        ],
+        "GT": Array [
+          "0|0",
+        ],
+        "HQ": Array [
+          51,
+          51,
+        ],
+      },
+      "NA00003": Object {
+        "DP": Array [
+          2,
+        ],
+        "GQ": Array [
+          61,
+        ],
+        "GT": Array [
+          "0/0",
+        ],
+        "HQ": null,
+      },
+    },
   },
-  Variant {
+  Object {
     "ALT": Array [
       "G",
       "GTCT",
     ],
     "CHROM": "20",
+    "FIELDS": Array [
+      "GT",
+      "GQ",
+      "DP",
+    ],
     "FILTER": "PASS",
     "ID": Array [
       "microsat1",
@@ -1747,6 +2338,41 @@ Array [
     "POS": 1234567,
     "QUAL": 50,
     "REF": "GTC",
+    "SAMPLES": Object {
+      "NA00001": Object {
+        "DP": Array [
+          4,
+        ],
+        "GQ": Array [
+          35,
+        ],
+        "GT": Array [
+          "0/1",
+        ],
+      },
+      "NA00002": Object {
+        "DP": Array [
+          2,
+        ],
+        "GQ": Array [
+          17,
+        ],
+        "GT": Array [
+          "0/2",
+        ],
+      },
+      "NA00003": Object {
+        "DP": Array [
+          3,
+        ],
+        "GQ": Array [
+          40,
+        ],
+        "GT": Array [
+          "1/1",
+        ],
+      },
+    },
   },
 ]
 `;

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -345,7 +345,7 @@ test('shortcut parsing with 1000 genomes', () => {
   expect(Object.keys(variants[0].SAMPLES).slice(0, 5)).toMatchSnapshot()
   expect(Object.keys(variants[0].SAMPLES).slice(-5)).toMatchSnapshot()
   const ret = variants.map(v => {
-    const { SAMPLES, ...rest } = v
+    const { SAMPLES, ...rest } = v.toJSON()
     return rest
   })
   expect(ret).toMatchSnapshot()


### PR DESCRIPTION
This creates a variant class instead of dynamically creating an object with properties for each feature. For many variant features this may be slightly more memory efficient since it doesn't have to create a new object with different prototype each time

I use toJSON in the test to avoid testing the "private fields" on the Variant object in the snapshot test, there might be a better way but this does pass tests minimally

This also adds a "FIELDS" property to the variant features that let's you find what fields are defined for the genotypes