### PR TITLE
Make a new BND field instead of storing Breakend in ALT

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ A list of sample names is also available in the `samples` attribute of the parse
 ## Breakends
 
 If a variant line has `SVTYPE=BND`, the `ALT` field will be examined for breakend
-specifications, and those will be parsed as objects.  For example:
+specifications, and those will be parsed and put in a 'BND' field.  For example:
 
 ```text
 13	123456	bnd_U	C	C[2:321682[,C[17:198983[	6	PASS	SVTYPE=BND;MATEID=bnd V,bnd Z
@@ -179,7 +179,8 @@ will be parsed as
     "bnd_U"
   ],
   "REF": "C",
-  "ALT": [
+  "ALT": ["C[2:321682[", "C[17:198983["]
+  "BND": [
     {
       "MateDirection": "right",
       "Replacement": "C",

--- a/src/parse.js
+++ b/src/parse.js
@@ -287,7 +287,7 @@ class VCF {
 
     // if this has SVTYPE=BND, parse ALTS for breakend descriptions
     if (variant.ALT && info && info.SVTYPE && info.SVTYPE[0] === 'BND') {
-      variant.ALT = variant.ALT.map(this._parseBreakend.bind(this))
+      variant.BND = variant.ALT.map(this._parseBreakend.bind(this))
     }
 
     // This creates a closure that allows us to attach "SAMPLES" as a lazy

--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -1322,6 +1322,9 @@ Object {
 exports[`VCF parser parses a line with a breakend ALT 1`] = `
 Variant {
   "ALT": Array [
+    "G]17:198982]",
+  ],
+  "BND": Array [
     Breakend {
       "Join": "right",
       "MateDirection": "left",
@@ -1348,6 +1351,11 @@ Variant {
 exports[`VCF parser parses a line with mix of multiple breakends and non breakends 1`] = `
 Variant {
   "ALT": Array [
+    "CTATGTCG",
+    "C[2 : 321682[",
+    "C[17 : 198983[",
+  ],
+  "BND": Array [
     "CTATGTCG",
     Breakend {
       "Join": "right",
@@ -1386,6 +1394,9 @@ exports[`can parse breakends 1`] = `
 Array [
   Variant {
     "ALT": Array [
+      "G]8:107653520]",
+    ],
+    "BND": Array [
       Breakend {
         "Join": "right",
         "MateDirection": "left",
@@ -1461,6 +1472,9 @@ Array [
   },
   Variant {
     "ALT": Array [
+      "T[8:107653411[",
+    ],
+    "BND": Array [
       Breakend {
         "Join": "right",
         "MateDirection": "right",

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -97,7 +97,7 @@ Object {
     )
     expect(variant.ALT.length).toBe(1)
     expect(variant.INFO.SVTYPE).toEqual(['BND'])
-    expect(variant.ALT[0] instanceof VCFParser.Breakend).toBe(true)
+    expect(variant.BND[0] instanceof VCFParser.Breakend).toBe(true)
     expect(variant).toMatchSnapshot()
   })
 
@@ -107,9 +107,9 @@ Object {
     )
     expect(variant.ALT.length).toBe(3)
     expect(variant.INFO.SVTYPE).toEqual(['BND'])
-    expect(variant.ALT[0] instanceof VCFParser.Breakend).toBe(false)
-    expect(variant.ALT[1] instanceof VCFParser.Breakend).toBe(true)
-    expect(variant.ALT[2] instanceof VCFParser.Breakend).toBe(true)
+    expect(variant.BND[0] instanceof VCFParser.Breakend).toBe(false)
+    expect(variant.BND[1] instanceof VCFParser.Breakend).toBe(true)
+    expect(variant.BND[2] instanceof VCFParser.Breakend).toBe(true)
     // console.log(JSON.stringify(variant, null, '  '));
     expect(variant).toMatchSnapshot()
   })


### PR DESCRIPTION
This is a little bit of "bikeshedding" issue but I think maintaining the original ALT string for the breakend is easier than making downstream code reason about the ALT being a string or a Breakend object. Then code that is interested in the parsed breakends can look in the BND field