### PR TITLE
Clone metadata object to avoid jest error about modifying read only

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -30,12 +30,14 @@ class VCF {
     // allow access to the Breakend class in case anybody wants to use it for checking
     this.Breakend = Breakend
     this.strict = args.strict !== undefined ? args.strict : true // true by default
-    this.metadata = {
-      INFO: vcfReserved.InfoFields,
-      FORMAT: vcfReserved.GenotypeFields,
-      ALT: vcfReserved.AltTypes,
-      FILTER: vcfReserved.FilterTypes,
-    }
+    this.metadata = JSON.parse(
+      JSON.stringify({
+        INFO: vcfReserved.InfoFields,
+        FORMAT: vcfReserved.GenotypeFields,
+        ALT: vcfReserved.AltTypes,
+        FILTER: vcfReserved.FilterTypes,
+      }),
+    )
     headerLines.forEach(line => {
       if (!line.startsWith('#')) {
         throw new Error(`Bad line in header:\n${line}`)


### PR DESCRIPTION
Error

```
   [ TypeError: Cannot assign to read only property 'DP' of object '#<Object>'
```

Seen here https://github.com/GMOD/jbrowse-components/pull/1853/checks?check_run_id=2205028779#step:5:23

Seems that simply use of parseMetadata in the jbrowse-components code produces this

