### PR TITLE
Remove the parseBreakends by default functionality

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "trailingComma": "all",
+  "singleQuote": true,
+}

--- a/README.md
+++ b/README.md
@@ -14,19 +14,17 @@ This module is best used when combined with some easy way of retrieving the
 header and individual lines from a VCF, like the `@gmod/tabix` module.
 
 ```javascript
-const { TabixIndexedFile } = require("@gmod/tabix");
-const VCF = require("@gmod/vcf");
+const { TabixIndexedFile } = require('@gmod/tabix')
+const VCF = require('@gmod/vcf')
 
-const tbiIndexed = new TabixIndexedFile({ path: "/path/to/my.vcf.gz" });
+const tbiIndexed = new TabixIndexedFile({ path: '/path/to/my.vcf.gz' })
 
 async function doStuff() {
-  const headerText = await tbiIndexed.getHeader();
-  const tbiVCFParser = new VCF({ header: headerText });
-  const variants = [];
-  await tbiIndexed.getLines("ctgA", 200, 300, line =>
-    variants.push(tbiVCFParser.parseLine(line))
-  );
-  console.log(variants);
+  const headerText = await tbiIndexed.getHeader()
+  const tbiVCFParser = new VCF({ header: headerText })
+  const variants = []
+  await tbiIndexed.getLines('ctgA', 200, 300, line => variants.push(tbiVCFParser.parseLine(line)))
+  console.log(variants)
 }
 ```
 
@@ -168,8 +166,8 @@ We offer a helper function to parse breakend strings. We used to parse these
 automatically but it is now a helper function
 
 ```js
-import { parseBreakend } from "@gmod/vcf";
-parseBreakend("C[2:321682[");
+import { parseBreakend } from '@gmod/vcf'
+parseBreakend('C[2:321682[')
 // output
 //
 //     {

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ This module is best used when combined with some easy way of retrieving the
 header and individual lines from a VCF, like the `@gmod/tabix` module.
 
 ```javascript
-const { TabixIndexedFile } = require('@gmod/tabix')
-const VCF = require('@gmod/vcf')
+const { TabixIndexedFile } = require("@gmod/tabix");
+const VCF = require("@gmod/vcf");
 
-const tbiIndexed = new TabixIndexedFile({ path: '/path/to/my.vcf.gz' })
+const tbiIndexed = new TabixIndexedFile({ path: "/path/to/my.vcf.gz" });
 
 async function doStuff() {
-  const headerText = await tbiIndexed.getHeader()
-  const tbiVCFParser = new VCF({ header: headerText })
-  const variants = []
-  await tbiIndexed.getLines('ctgA', 200, 300, line =>
-    variants.push(tbiVCFParser.parseLine(line)),
-  )
-  console.log(variants)
+  const headerText = await tbiIndexed.getHeader();
+  const tbiVCFParser = new VCF({ header: headerText });
+  const variants = [];
+  await tbiIndexed.getLines("ctgA", 200, 300, line =>
+    variants.push(tbiVCFParser.parseLine(line))
+  );
+  console.log(variants);
 }
 ```
 
@@ -164,53 +164,17 @@ A list of sample names is also available in the `samples` attribute of the parse
 
 ## Breakends
 
-If a variant line has `SVTYPE=BND`, the `ALT` field will be examined for breakend
-specifications, and those will be parsed as objects.  For example:
+We offer a helper function to parse breakend strings. We used to parse these
+automatically but it is now a helper function
 
-```text
-13	123456	bnd_U	C	C[2:321682[,C[17:198983[	6	PASS	SVTYPE=BND;MATEID=bnd V,bnd Z
+import {parseBreakend} from '@gmod/vcf' and call e.g.
+
 ```
-
-will be parsed as
-
-```json
-{
-  "CHROM": "13",
-  "POS": 123456,
-  "ID": [
-    "bnd_U"
-  ],
-  "REF": "C",
-  "ALT": [
-    {
-      "MateDirection": "right",
-      "Replacement": "C",
-      "MatePosition": "2:321682",
-      "Join": "right"
-    },
-    {
-      "MateDirection": "right",
-      "Replacement": "C",
-      "MatePosition": "17:198983",
-      "Join": "right"
-    }
-  ],
-  "QUAL": 6,
-  "FILTER": "PASS",
-  "INFO": {
-    "SVTYPE": [
-      "BND"
-    ],
-    "MATEID": [
-      "bnd V",
-      "bnd Z"
-    ]
-  }
-}
+parseBreakend('C[2:321682[')
 ```
 
 The C\[2:321682\[ parses as "Join": "right" because the BND is after the C base
-The C\[2:321682\[ also is given "MateDirection": "right" because the square brackets point to the right. 
+The C\[2:321682\[ also is given "MateDirection": "right" because the square brackets point to the right.
 The spec never has the square brackets pointing in different directions. Instead, the different types of joins
 can be imagined as follows
 
@@ -253,18 +217,18 @@ the breakend structure looks like this
 
 #### Table of Contents
 
--   [VCF](#vcf)
-    -   [Parameters](#parameters)
-    -   [\_parseMetadata](#_parsemetadata)
-        -   [Parameters](#parameters-1)
-    -   [\_parseStructuredMetaVal](#_parsestructuredmetaval)
-        -   [Parameters](#parameters-2)
-    -   [getMetadata](#getmetadata)
-        -   [Parameters](#parameters-3)
-    -   [\_parseKeyValue](#_parsekeyvalue)
-        -   [Parameters](#parameters-4)
-    -   [parseLine](#parseline)
-        -   [Parameters](#parameters-5)
+- [VCF](#vcf)
+  - [Parameters](#parameters)
+  - [\_parseMetadata](#_parsemetadata)
+    - [Parameters](#parameters-1)
+  - [\_parseStructuredMetaVal](#_parsestructuredmetaval)
+    - [Parameters](#parameters-2)
+  - [getMetadata](#getmetadata)
+    - [Parameters](#parameters-3)
+  - [\_parseKeyValue](#_parsekeyvalue)
+    - [Parameters](#parameters-4)
+  - [parseLine](#parseline)
+    - [Parameters](#parameters-5)
 
 ### VCF
 
@@ -272,10 +236,10 @@ Class representing a VCF parser, instantiated with the VCF header.
 
 #### Parameters
 
--   `args` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
-    -   `args.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The VCF header. Supports both LF and CRLF
-        newlines.
-    -   `args.strict` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to parse in strict mode or not (default true)
+- `args` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**
+  - `args.header` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The VCF header. Supports both LF and CRLF
+    newlines.
+  - `args.strict` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether to parse in strict mode or not (default true)
 
 #### \_parseMetadata
 
@@ -284,8 +248,8 @@ properties to the object.
 
 ##### Parameters
 
--   `line` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** A line from the VCF. Supports both LF and CRLF
-    newlines.
+- `line` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** A line from the VCF. Supports both LF and CRLF
+  newlines.
 
 #### \_parseStructuredMetaVal
 
@@ -294,7 +258,7 @@ with "&lt;ID=...")
 
 ##### Parameters
 
--   `metaVal` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The VCF metadata value
+- `metaVal` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The VCF metadata value
 
 Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)** Array with two entries, 1) a string of the metadata ID
 and 2) an object with the other key-value pairs in the metadata
@@ -307,7 +271,7 @@ Get metadata filtered by the elements in args. For example, can pass
 
 ##### Parameters
 
--   `args` **...[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** List of metadata filter strings.
+- `args` **...[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** List of metadata filter strings.
 
 Returns **any** An object, string, or number, depending on the filtering
 
@@ -323,9 +287,9 @@ separator). Above line would be parsed to:
 
 ##### Parameters
 
--   `str` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Key-value pairs in a string
--   `pairSeparator` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** A string that separates sets of key-value
-    pairs (optional, default `';'`)
+- `str` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Key-value pairs in a string
+- `pairSeparator` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** A string that separates sets of key-value
+  pairs (optional, default `';'`)
 
 Returns **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** An object containing the key-value pairs
 
@@ -336,5 +300,5 @@ INFO } with SAMPLES optionally included if present in the VCF
 
 ##### Parameters
 
--   `line` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** A string of a line from a VCF. Supports both LF and
-    CRLF newlines.
+- `line` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** A string of a line from a VCF. Supports both LF and
+  CRLF newlines.

--- a/README.md
+++ b/README.md
@@ -167,16 +167,25 @@ A list of sample names is also available in the `samples` attribute of the parse
 We offer a helper function to parse breakend strings. We used to parse these
 automatically but it is now a helper function
 
-import {parseBreakend} from '@gmod/vcf' and call e.g.
-
+```js
+import { parseBreakend } from "@gmod/vcf";
+parseBreakend("C[2:321682[");
+// output
+//
+//     {
+//       "MateDirection": "right",
+//       "Replacement": "C",
+//       "MatePosition": "2:321682",
+//       "Join": "right"
+//     }
 ```
-parseBreakend('C[2:321682[')
-```
 
-The C\[2:321682\[ parses as "Join": "right" because the BND is after the C base
-The C\[2:321682\[ also is given "MateDirection": "right" because the square brackets point to the right.
-The spec never has the square brackets pointing in different directions. Instead, the different types of joins
-can be imagined as follows
+- The C\[2:321682\[ parses as "Join": "right" because the BND is after the C
+  base
+- The C\[2:321682\[ also is given "MateDirection": "right" because the square
+  brackets point to the right.
+- The spec never has the square brackets pointing in different directions.
+  Instead, the different types of joins can be imagined as follows
 
 For the above vcf line where chr13:123456->C\[2:321682\[ then we have this
 
@@ -192,8 +201,9 @@ For the above vcf line where chr13:123456->C\[2:321682\[ then we have this
                             \--------------
                              chr2:321682
 
-If the alt was instead chr13:123456->\[2:321682\[C then the the "Join" would be "left" since the "BND" is before "C" and then
-the breakend structure looks like this
+If the alt was instead chr13:123456->\[2:321682\[C then the the "Join" would be
+"left" since the "BND" is before "C" and then the breakend structure looks like
+this
 
           chr13:123456
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,28 @@
-/** @module VCF */
-const VCF = require('./parse')
+import VCF from './parse'
 
-module.exports = VCF
+export function parseBreakend(breakendString) {
+  const tokens = breakendString.split(/[[\]]/)
+  if (tokens.length > 1) {
+    const parsed = {}
+    parsed.MateDirection = breakendString.includes('[') ? 'right' : 'left'
+    for (let i = 0; i < tokens.length; i += 1) {
+      const tok = tokens[i]
+      if (tok) {
+        if (tok.includes(':')) {
+          // this is the remote location
+          parsed.MatePosition = tok
+          parsed.Join = parsed.Replacement ? 'right' : 'left'
+        } else {
+          // this is the local alteration
+          parsed.Replacement = tok
+        }
+      }
+    }
+    return parsed
+  }
+  // if there is not more than one token, there are no [ or ] characters,
+  // so just return it unmodified
+  return breakendString
+}
+
+export default VCF

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,7 @@ export function parseBreakend(breakendString) {
     }
     return parsed
   }
-  // if there is not more than one token, there are no [ or ] characters,
-  // so just return it unmodified
-  return breakendString
+  return undefined
 }
 
 export default VCF

--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -1170,12 +1170,7 @@ Object {
 exports[`VCF parser parses a line with a breakend ALT 1`] = `
 Variant {
   "ALT": Array [
-    Breakend {
-      "Join": "right",
-      "MateDirection": "left",
-      "MatePosition": "17:198982",
-      "Replacement": "G",
-    },
+    "G]17:198982]",
   ],
   "CHROM": "2",
   "FILTER": "PASS",
@@ -1197,18 +1192,8 @@ exports[`VCF parser parses a line with mix of multiple breakends and non breaken
 Variant {
   "ALT": Array [
     "CTATGTCG",
-    Breakend {
-      "Join": "right",
-      "MateDirection": "right",
-      "MatePosition": "2 : 321682",
-      "Replacement": "C",
-    },
-    Breakend {
-      "Join": "right",
-      "MateDirection": "right",
-      "MatePosition": "17 : 198983",
-      "Replacement": "C",
-    },
+    "C[2 : 321682[",
+    "C[17 : 198983[",
   ],
   "CHROM": "13",
   "FILTER": "PASS",
@@ -1234,12 +1219,7 @@ exports[`can parse breakends 1`] = `
 Array [
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "right",
-        "MateDirection": "left",
-        "MatePosition": "8:107653520",
-        "Replacement": "G",
-      },
+      "G]8:107653520]",
     ],
     "CHROM": "11",
     "FILTER": "PASS",
@@ -1309,12 +1289,7 @@ Array [
   },
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "right",
-        "MateDirection": "right",
-        "MatePosition": "8:107653411",
-        "Replacement": "T",
-      },
+      "T[8:107653411[",
     ],
     "CHROM": "11",
     "FILTER": "PASS",
@@ -1473,12 +1448,7 @@ exports[`shortcut parsing with vcf 4.3 bnd example 1`] = `
 Array [
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "right",
-        "MateDirection": "left",
-        "MatePosition": "17:198982",
-        "Replacement": "G",
-      },
+      "G]17:198982]",
     ],
     "CHROM": "2",
     "FILTER": "PASS",
@@ -1496,12 +1466,7 @@ Array [
   },
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "left",
-        "MateDirection": "left",
-        "MatePosition": "13:123456",
-        "Replacement": "T",
-      },
+      "]13:123456]T",
     ],
     "CHROM": "2",
     "FILTER": "PASS",
@@ -1519,12 +1484,7 @@ Array [
   },
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "right",
-        "MateDirection": "right",
-        "MatePosition": "2:321682",
-        "Replacement": "C",
-      },
+      "C[2:321682[",
     ],
     "CHROM": "13",
     "FILTER": "PASS",
@@ -1542,12 +1502,7 @@ Array [
   },
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "left",
-        "MateDirection": "right",
-        "MatePosition": "17:198983",
-        "Replacement": "A",
-      },
+      "[17:198983[A",
     ],
     "CHROM": "13",
     "FILTER": "PASS",
@@ -1565,12 +1520,7 @@ Array [
   },
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "right",
-        "MateDirection": "left",
-        "MatePosition": "2:321681",
-        "Replacement": "A",
-      },
+      "A]2:321681]",
     ],
     "CHROM": "17",
     "FILTER": "PASS",
@@ -1588,12 +1538,7 @@ Array [
   },
   Variant {
     "ALT": Array [
-      Breakend {
-        "Join": "left",
-        "MateDirection": "right",
-        "MatePosition": "13:123457",
-        "Replacement": "C",
-      },
+      "[13:123457[C",
     ],
     "CHROM": "17",
     "FILTER": "PASS",
@@ -1962,7 +1907,7 @@ Array [
 `;
 
 exports[`vcf 4.3 single breakends 1`] = `
-Breakend {
+Object {
   "Join": "right",
   "MateDirection": "right",
   "MatePosition": "<ctg1>:1",
@@ -1971,7 +1916,7 @@ Breakend {
 `;
 
 exports[`vcf 4.3 single breakends 2`] = `
-Breakend {
+Object {
   "Join": "right",
   "MateDirection": "right",
   "MatePosition": "13:123457",
@@ -1980,7 +1925,7 @@ Breakend {
 `;
 
 exports[`vcf 4.3 single breakends 3`] = `
-Breakend {
+Object {
   "Join": "left",
   "MateDirection": "left",
   "MatePosition": "13:123456",

--- a/test/__snapshots__/parse.test.js.snap
+++ b/test/__snapshots__/parse.test.js.snap
@@ -1933,4 +1933,4 @@ Object {
 }
 `;
 
-exports[`vcf 4.3 single breakends 4`] = `"G."`;
+exports[`vcf 4.3 single breakends 4`] = `undefined`;


### PR DESCRIPTION
This addresses #68

The code exports a parseBreakend function which users can use if they are interested, but by default does not do parsing