### PR TITLE
Make constructor's "strict" be optional

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -26,7 +26,7 @@ export default class VCF {
     strict = true,
   }: {
     header: string
-    strict: boolean
+    strict?: boolean
   }) {
     if (!header || !header.length) {
       throw new Error('empty header received')


### PR DESCRIPTION
This makes `strict` in the parser's constructor be optional. It already is optional since it has a default value, this just convinces TypeScript that that's the case.