### PR TITLE
Add Breakend interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 import VCF from './parse'
 
-export function parseBreakend(breakendString: string) {
+export interface Breakend {
+  MatePosition: string
+  Join: string
+  Replacement: string
+  MateDirection: string
+}
+
+export function parseBreakend(breakendString: string): Breakend | undefined {
   const tokens = breakendString.split(/[[\]]/)
   if (tokens.length > 1) {
     const MateDirection = breakendString.includes('[') ? 'right' : 'left'
@@ -19,6 +26,9 @@ export function parseBreakend(breakendString: string) {
           Replacement = tok
         }
       }
+    }
+    if (!(MatePosition && Join && Replacement)) {
+      throw new Error(`Invalid breakend: ${breakendString}`)
     }
     return { MatePosition, Join, Replacement, MateDirection }
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,64 +1,74 @@
 import { parseBreakend, Breakend } from '../src'
 
-test('can parse breakends', () => {
-  // Breakends from https://samtools.github.io/hts-specs/VCFv4.3.pdf
-  const breakendsAndParsed = [
-    [
-      'G]17:198982]',
-      {
-        MatePosition: '17:198982',
-        Join: 'right',
-        Replacement: 'G',
-        MateDirection: 'left',
-      },
-    ],
-    [
-      ']13:123456]T',
-      {
-        MatePosition: '13:123456',
-        Join: 'left',
-        Replacement: 'T',
-        MateDirection: 'left',
-      },
-    ],
-    [
-      'C[2:321682[',
-      {
-        MatePosition: '2:321682',
-        Join: 'right',
-        Replacement: 'C',
-        MateDirection: 'right',
-      },
-    ],
-    [
-      '[17:198983[A',
-      {
-        MatePosition: '17:198983',
-        Join: 'left',
-        Replacement: 'A',
-        MateDirection: 'right',
-      },
-    ],
-    [
-      'A]2:321681]',
-      {
-        MatePosition: '2:321681',
-        Join: 'right',
-        Replacement: 'A',
-        MateDirection: 'left',
-      },
-    ],
-    [
-      '[13:123457[C',
-      {
-        MatePosition: '13:123457',
-        Join: 'left',
-        Replacement: 'C',
-        MateDirection: 'right',
-      },
-    ],
-  ] as [string, Breakend][]
-  breakendsAndParsed.forEach(([breakend, parsedBreakend]) => {
-    expect(parseBreakend(breakend)).toEqual(parsedBreakend)
+describe('testBreakend', () => {
+  it('can parse breakends', () => {
+    // Breakends from https://samtools.github.io/hts-specs/VCFv4.3.pdf
+    const breakendsAndParsed = [
+      [
+        'G]17:198982]',
+        {
+          MatePosition: '17:198982',
+          Join: 'right',
+          Replacement: 'G',
+          MateDirection: 'left',
+        },
+      ],
+      [
+        ']13:123456]T',
+        {
+          MatePosition: '13:123456',
+          Join: 'left',
+          Replacement: 'T',
+          MateDirection: 'left',
+        },
+      ],
+      [
+        'C[2:321682[',
+        {
+          MatePosition: '2:321682',
+          Join: 'right',
+          Replacement: 'C',
+          MateDirection: 'right',
+        },
+      ],
+      [
+        '[17:198983[A',
+        {
+          MatePosition: '17:198983',
+          Join: 'left',
+          Replacement: 'A',
+          MateDirection: 'right',
+        },
+      ],
+      [
+        'A]2:321681]',
+        {
+          MatePosition: '2:321681',
+          Join: 'right',
+          Replacement: 'A',
+          MateDirection: 'left',
+        },
+      ],
+      [
+        '[13:123457[C',
+        {
+          MatePosition: '13:123457',
+          Join: 'left',
+          Replacement: 'C',
+          MateDirection: 'right',
+        },
+      ],
+    ] as [string, Breakend][]
+    breakendsAndParsed.forEach(([breakend, parsedBreakend]) => {
+      expect(parseBreakend(breakend)).toEqual(parsedBreakend)
+    })
+  })
+
+  it('throws on invalid breakend', () => {
+    expect(() => parseBreakend('[13:123457[')).toThrow(/Invalid breakend/)
+  })
+
+  it('returns "undefined" for non-breakend', () => {
+    expect(parseBreakend('A')).toBeUndefined()
   })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,64 @@
+import { parseBreakend, Breakend } from '../src'
+
+test('can parse breakends', () => {
+  // Breakends from https://samtools.github.io/hts-specs/VCFv4.3.pdf
+  const breakendsAndParsed = [
+    [
+      'G]17:198982]',
+      {
+        MatePosition: '17:198982',
+        Join: 'right',
+        Replacement: 'G',
+        MateDirection: 'left',
+      },
+    ],
+    [
+      ']13:123456]T',
+      {
+        MatePosition: '13:123456',
+        Join: 'left',
+        Replacement: 'T',
+        MateDirection: 'left',
+      },
+    ],
+    [
+      'C[2:321682[',
+      {
+        MatePosition: '2:321682',
+        Join: 'right',
+        Replacement: 'C',
+        MateDirection: 'right',
+      },
+    ],
+    [
+      '[17:198983[A',
+      {
+        MatePosition: '17:198983',
+        Join: 'left',
+        Replacement: 'A',
+        MateDirection: 'right',
+      },
+    ],
+    [
+      'A]2:321681]',
+      {
+        MatePosition: '2:321681',
+        Join: 'right',
+        Replacement: 'A',
+        MateDirection: 'left',
+      },
+    ],
+    [
+      '[13:123457[C',
+      {
+        MatePosition: '13:123457',
+        Join: 'left',
+        Replacement: 'C',
+        MateDirection: 'right',
+      },
+    ],
+  ] as [string, Breakend][]
+  breakendsAndParsed.forEach(([breakend, parsedBreakend]) => {
+    expect(parseBreakend(breakend)).toEqual(parsedBreakend)
+  })
+})


### PR DESCRIPTION
This adds a `Breakend` interface that users can import, as well as ensuring that `parseBreakend` returns a valid `Breakend`. As far as I can tell with the spec, there shouldn't be any reason that `Mate`, `Join`, or `Replacement` should be undefined in a valid breakend.