### PR TITLE
Remove hard throw when there is a FORMAT field but no genotypes/samples

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -79,8 +79,6 @@ export default class VCF {
     ]
     if (fields.length < 8) {
       throw new Error(`VCF header missing columns:\n${lastLine}`)
-    } else if (fields.length === 9) {
-      throw new Error(`VCF header has FORMAT but no samples:\n${lastLine}`)
     } else if (
       thisHeader.length !== correctHeader.length ||
       !thisHeader.every((value, index) => value === correctHeader[index])

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -127,11 +127,6 @@ describe('VCF parser', () => {
     }).toThrow('VCF header missing columns')
     expect(() => {
       new VCF({
-        header: '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\n',
-      })
-    }).toThrow('VCF header has FORMAT but no samples')
-    expect(() => {
-      new VCF({
         header: '#CHROM\tPS\tID\tRF\tALT\tQUAL\tFILTER\tINFO\n',
       })
     }).toThrow('VCF column headers not correct')


### PR DESCRIPTION
I had an example of a VCF like this from Ensembl VEP


I think it may be unnecessarily strict to reject the VCF outright. It does not really affect anything if there is a format field and no genotypes (the FORMAT field normally governs the "format of the sample specific genotype columns" following it)