### PR TITLE
Parse single breakends and large insertion shorthand notation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,17 +33,17 @@ export function parseBreakend(breakendString: string): Breakend | undefined {
     }
     return { MatePosition, Join, Replacement, MateDirection }
   } else {
-    if (breakendString[0] === '.') {
+    if (breakendString.startsWith('.')) {
       return {
         Join: 'left',
         SingleBreakend: true,
         Replacement: breakendString.slice(1),
       }
-    } else if (breakendString[1] === '.') {
+    } else if (breakendString.endsWith('.')) {
       return {
         Join: 'right',
         SingleBreakend: true,
-        Replacement: breakendString[0],
+        Replacement: breakendString.slice(0, breakendString.length - 1),
       }
     } else if (breakendString[0] === '<') {
       const res = breakendString.match('<(.*)>(.*)')
@@ -54,7 +54,7 @@ export function parseBreakend(breakendString: string): Breakend | undefined {
         Join: 'left',
         Replacement: res?.[2],
         MateDirection: 'right',
-        MatePosition: `<${res?.[2]}>:1`,
+        MatePosition: `<${res?.[1]}>:1`,
       }
     } else if (breakendString.includes('<')) {
       const res = breakendString.match('(.*)<(.*)>')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import VCF from './parse'
 
 export interface Breakend {
-  MatePosition: string
   Join: string
   Replacement: string
-  MateDirection: string
+  MatePosition?: string
+  MateDirection?: string
+  SingleBreakend?: boolean
 }
 
 export function parseBreakend(breakendString: string): Breakend | undefined {
@@ -31,6 +32,42 @@ export function parseBreakend(breakendString: string): Breakend | undefined {
       throw new Error(`Invalid breakend: ${breakendString}`)
     }
     return { MatePosition, Join, Replacement, MateDirection }
+  } else {
+    if (breakendString[0] === '.') {
+      return {
+        Join: 'left',
+        SingleBreakend: true,
+        Replacement: breakendString.slice(1),
+      }
+    } else if (breakendString[1] === '.') {
+      return {
+        Join: 'right',
+        SingleBreakend: true,
+        Replacement: breakendString[0],
+      }
+    } else if (breakendString[0] === '<') {
+      const res = breakendString.match('<(.*)>(.*)')
+      if (!res) {
+        throw new Error(`failed to parse ${breakendString}`)
+      }
+      return {
+        Join: 'left',
+        Replacement: res?.[2],
+        MateDirection: 'right',
+        MatePosition: `<${res?.[2]}>:1`,
+      }
+    } else if (breakendString.includes('<')) {
+      const res = breakendString.match('(.*)<(.*)>')
+      if (!res) {
+        throw new Error(`failed to parse ${breakendString}`)
+      }
+      return {
+        Join: 'right',
+        Replacement: res?.[1],
+        MateDirection: 'right',
+        MatePosition: `<${res?.[2]}>:1`,
+      }
+    }
   }
   return undefined
 }

--- a/test/__snapshots__/parse.test.ts.snap
+++ b/test/__snapshots__/parse.test.ts.snap
@@ -1933,4 +1933,28 @@ Object {
 }
 `;
 
-exports[`vcf 4.3 single breakends 4`] = `undefined`;
+exports[`vcf 4.3 single breakends 4`] = `
+Object {
+  "Join": "right",
+  "Replacement": "G",
+  "SingleBreakend": true,
+}
+`;
+
+exports[`vcf 4.3 single breakends 5`] = `
+Object {
+  "Join": "right",
+  "MateDirection": "right",
+  "MatePosition": "<ctgA>:1",
+  "Replacement": "G",
+}
+`;
+
+exports[`vcf 4.3 single breakends 6`] = `
+Object {
+  "Join": "left",
+  "MateDirection": "right",
+  "MatePosition": "<G>:1",
+  "Replacement": "G",
+}
+`;

--- a/test/__snapshots__/parse.test.ts.snap
+++ b/test/__snapshots__/parse.test.ts.snap
@@ -1944,17 +1944,33 @@ Object {
 exports[`vcf 4.3 single breakends 5`] = `
 Object {
   "Join": "right",
-  "MateDirection": "right",
-  "MatePosition": "<ctgA>:1",
-  "Replacement": "G",
+  "Replacement": "ACGT",
+  "SingleBreakend": true,
 }
 `;
 
 exports[`vcf 4.3 single breakends 6`] = `
 Object {
   "Join": "left",
+  "Replacement": "ACGT",
+  "SingleBreakend": true,
+}
+`;
+
+exports[`vcf 4.3 single breakends 7`] = `
+Object {
+  "Join": "right",
   "MateDirection": "right",
-  "MatePosition": "<G>:1",
+  "MatePosition": "<ctgA>:1",
+  "Replacement": "G",
+}
+`;
+
+exports[`vcf 4.3 single breakends 8`] = `
+Object {
+  "Join": "left",
+  "MateDirection": "right",
+  "MatePosition": "<ctgA>:1",
   "Replacement": "G",
 }
 `;

--- a/test/__snapshots__/parse.test.ts.snap
+++ b/test/__snapshots__/parse.test.ts.snap
@@ -1906,7 +1906,25 @@ Array [
 ]
 `;
 
-exports[`vcf 4.3 single breakends 1`] = `
+exports[`vcf 4.3 insertion shorthand 1`] = `
+Object {
+  "Join": "right",
+  "MateDirection": "right",
+  "MatePosition": "<ctgA>:1",
+  "Replacement": "G",
+}
+`;
+
+exports[`vcf 4.3 insertion shorthand 2`] = `
+Object {
+  "Join": "left",
+  "MateDirection": "right",
+  "MatePosition": "<ctgA>:1",
+  "Replacement": "G",
+}
+`;
+
+exports[`vcf 4.3 insertion shorthand 3`] = `
 Object {
   "Join": "right",
   "MateDirection": "right",
@@ -1915,16 +1933,7 @@ Object {
 }
 `;
 
-exports[`vcf 4.3 single breakends 2`] = `
-Object {
-  "Join": "right",
-  "MateDirection": "right",
-  "MatePosition": "13:123457",
-  "Replacement": ".",
-}
-`;
-
-exports[`vcf 4.3 single breakends 3`] = `
+exports[`vcf 4.3 insertion shorthand 4`] = `
 Object {
   "Join": "left",
   "MateDirection": "left",
@@ -1933,7 +1942,7 @@ Object {
 }
 `;
 
-exports[`vcf 4.3 single breakends 4`] = `
+exports[`vcf 4.3 single breakends 1`] = `
 Object {
   "Join": "right",
   "Replacement": "G",
@@ -1941,7 +1950,7 @@ Object {
 }
 `;
 
-exports[`vcf 4.3 single breakends 5`] = `
+exports[`vcf 4.3 single breakends 2`] = `
 Object {
   "Join": "right",
   "Replacement": "ACGT",
@@ -1949,28 +1958,10 @@ Object {
 }
 `;
 
-exports[`vcf 4.3 single breakends 6`] = `
+exports[`vcf 4.3 single breakends 3`] = `
 Object {
   "Join": "left",
   "Replacement": "ACGT",
   "SingleBreakend": true,
-}
-`;
-
-exports[`vcf 4.3 single breakends 7`] = `
-Object {
-  "Join": "right",
-  "MateDirection": "right",
-  "MatePosition": "<ctgA>:1",
-  "Replacement": "G",
-}
-`;
-
-exports[`vcf 4.3 single breakends 8`] = `
-Object {
-  "Join": "left",
-  "MateDirection": "right",
-  "MatePosition": "<ctgA>:1",
-  "Replacement": "G",
 }
 `;

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -352,4 +352,6 @@ test('vcf 4.3 single breakends', () => {
   // large insertion
   expect(parseBreakend(']13:123456]AGTNNNNNCAT')).toMatchSnapshot()
   expect(parseBreakend('G.')).toMatchSnapshot()
+  expect(parseBreakend('G<ctgA>')).toMatchSnapshot()
+  expect(parseBreakend('<ctgA>G')).toMatchSnapshot()
 })

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -352,6 +352,8 @@ test('vcf 4.3 single breakends', () => {
   // large insertion
   expect(parseBreakend(']13:123456]AGTNNNNNCAT')).toMatchSnapshot()
   expect(parseBreakend('G.')).toMatchSnapshot()
+  expect(parseBreakend('ACGT.')).toMatchSnapshot()
+  expect(parseBreakend('.ACGT')).toMatchSnapshot()
   expect(parseBreakend('G<ctgA>')).toMatchSnapshot()
   expect(parseBreakend('<ctgA>G')).toMatchSnapshot()
 })

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -345,15 +345,15 @@ test('shortcut parsing with vcf 4.3 bnd example', () => {
 })
 
 test('vcf 4.3 single breakends', () => {
-  // inserted contig
-  expect(parseBreakend('C[<ctg1>:1[')).toMatchSnapshot()
   // single breakend
-  expect(parseBreakend('.[13:123457')).toMatchSnapshot()
-  // large insertion
-  expect(parseBreakend(']13:123456]AGTNNNNNCAT')).toMatchSnapshot()
   expect(parseBreakend('G.')).toMatchSnapshot()
   expect(parseBreakend('ACGT.')).toMatchSnapshot()
   expect(parseBreakend('.ACGT')).toMatchSnapshot()
+})
+
+test('vcf 4.3 insertion shorthand', () => {
   expect(parseBreakend('G<ctgA>')).toMatchSnapshot()
   expect(parseBreakend('<ctgA>G')).toMatchSnapshot()
+  expect(parseBreakend('C[<ctg1>:1[')).toMatchSnapshot()
+  expect(parseBreakend(']13:123456]AGTNNNNNCAT')).toMatchSnapshot()
 })


### PR DESCRIPTION
Parses `G.` and `G<ctgA>` more correctly, producing respectively

```json
{
  "Join": "right",
  "Replacement": "G",
  "SingleBreakend": true,
}
 // just ends after G, it is a "single breakend" a la 5.4.9 https://samtools.github.io/hts-specs/VCFv4.3.pdf so we have no Mate
```

```json

{
  "Join": "left",
  "MateDirection": "right",
  "MatePosition": "<ctgA>:1",
  "Replacement": "G",
}
 // a large insertion of ctgA to the right of G
```

On current master, `G.` and `G<ctgA>` parses as undefined