### PR TITLE
Fix erroneous parsing of symbolic alleles as breakends

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,23 +50,29 @@ export function parseBreakend(breakendString: string): Breakend | undefined {
       if (!res) {
         throw new Error(`failed to parse ${breakendString}`)
       }
-      return {
-        Join: 'left',
-        Replacement: res?.[2],
-        MateDirection: 'right',
-        MatePosition: `<${res?.[1]}>:1`,
-      }
+      const Replacement = res?.[2]
+      return Replacement
+        ? {
+            Join: 'left',
+            Replacement,
+            MateDirection: 'right',
+            MatePosition: `<${res?.[1]}>:1`,
+          }
+        : undefined
     } else if (breakendString.includes('<')) {
       const res = breakendString.match('(.*)<(.*)>')
       if (!res) {
         throw new Error(`failed to parse ${breakendString}`)
       }
-      return {
-        Join: 'right',
-        Replacement: res?.[1],
-        MateDirection: 'right',
-        MatePosition: `<${res?.[2]}>:1`,
-      }
+      const Replacement = res?.[1]
+      return Replacement
+        ? {
+            Join: 'right',
+            Replacement,
+            MateDirection: 'right',
+            MatePosition: `<${res?.[2]}>:1`,
+          }
+        : undefined
     }
   }
   return undefined

--- a/test/__snapshots__/parse.test.ts.snap
+++ b/test/__snapshots__/parse.test.ts.snap
@@ -1317,6 +1317,15 @@ exports[`can parse breakends 1`] = `
 ]
 `;
 
+exports[`parse breakend on thing that looks like symbolic allele but is actually a feature 1`] = `
+{
+  "Join": "left",
+  "MateDirection": "right",
+  "MatePosition": "<INV>:1",
+  "Replacement": "C",
+}
+`;
+
 exports[`shortcut parsing with 1000 genomes 1`] = `
 [
   "HG00096",

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -357,3 +357,14 @@ test('vcf 4.3 insertion shorthand', () => {
   expect(parseBreakend('C[<ctg1>:1[')).toMatchSnapshot()
   expect(parseBreakend(']13:123456]AGTNNNNNCAT')).toMatchSnapshot()
 })
+
+test('parse breakend on symbolic alleles', () => {
+  expect(parseBreakend('<TRA>')).not.toBeTruthy()
+  expect(parseBreakend('<INS>')).not.toBeTruthy()
+  expect(parseBreakend('<DEL>')).not.toBeTruthy()
+  expect(parseBreakend('<INV>')).not.toBeTruthy()
+})
+
+test('parse breakend on thing that looks like symbolic allele but is actually a feature', () => {
+  expect(parseBreakend('<INV>C')).toMatchSnapshot()
+})


### PR DESCRIPTION
PR https://github.com/GMOD/vcf-js/pull/95 introduced a regression where it conceived of symbolic alleles like `<INV>` to be breakends

I change the code here to require the "Replacement" string, so it must be e.g. `<INV>C` to indicate that it's part of a breakend, the current code currently allows returning an undefined replacement which is ambiguous