### PR TITLE
Fix GT substring match

### DIFF
--- a/src/processGenotypes.ts
+++ b/src/processGenotypes.ts
@@ -20,6 +20,34 @@ export type GenotypeCallback = (
  * @param samplesLen - Number of samples
  * @param callback - Called for each genotype with (string, startIndex, endIndex)
  */
+const TAB = 9
+const COLON = 58
+const G = 71
+const T = 84
+
+// Column index of the exact "GT" field among the colon-separated FORMAT
+// keys, or -1 if absent. Matches the field exactly so keys that merely
+// contain "GT" (e.g. GATK's PGT) are not mistaken for it.
+function gtColumnIndex(format: string) {
+  let col = 0
+  let start = 0
+  const len = format.length
+  for (let j = 0; j <= len; j++) {
+    if (j === len || format.charCodeAt(j) === COLON) {
+      if (
+        j - start === 2 &&
+        format.charCodeAt(start) === G &&
+        format.charCodeAt(start + 1) === T
+      ) {
+        return col
+      }
+      col++
+      start = j + 1
+    }
+  }
+  return -1
+}
+
 export function processGenotypes(
   format: string,
   prerest: string,
@@ -27,8 +55,6 @@ export function processGenotypes(
   callback: GenotypeCallback,
 ) {
   const prerestLen = prerest.length
-  const TAB = 9
-  const COLON = 58
   let pos = 0
 
   // Fast path: format is exactly "GT"
@@ -44,14 +70,13 @@ export function processGenotypes(
     return
   }
 
-  // Check if GT field exists
-  const gtIdx = format.indexOf('GT')
-  if (gtIdx === -1) {
+  const colonCount = gtColumnIndex(format)
+  if (colonCount === -1) {
     return
   }
 
   // GT is first field but not only field
-  if (gtIdx === 0) {
+  if (colonCount === 0) {
     for (let idx = 0; idx < samplesLen; idx++) {
       const start = pos
       while (
@@ -70,14 +95,7 @@ export function processGenotypes(
     return
   }
 
-  // GT is not first field - need to skip to the right column
-  let colonCount = 0
-  for (let j = 0; j < gtIdx; j++) {
-    if (format.charCodeAt(j) === COLON) {
-      colonCount++
-    }
-  }
-
+  // GT is not first field - skip to its column (colonCount fields precede it)
   for (let idx = 0; idx < samplesLen; idx++) {
     const sampleStart = pos
     let tabIdx = pos

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -68,6 +68,82 @@ describe('testBreakend', () => {
     })
   })
 
+  it('parses telomeric breakends (VCFv4.5 section 5.4.5)', () => {
+    // virtual telomeric breakends use positions 0 and N+1
+    const telomeresAndParsed = [
+      [
+        '.[13:123457[',
+        {
+          MatePosition: '13:123457',
+          Join: 'right',
+          Replacement: '.',
+          MateDirection: 'right',
+        },
+      ],
+      [
+        'C[1:1[',
+        {
+          MatePosition: '1:1',
+          Join: 'right',
+          Replacement: 'C',
+          MateDirection: 'right',
+        },
+      ],
+      [
+        ']1:0]A',
+        {
+          MatePosition: '1:0',
+          Join: 'left',
+          Replacement: 'A',
+          MateDirection: 'left',
+        },
+      ],
+    ] as [string, Breakend][]
+    telomeresAndParsed.forEach(([breakend, parsedBreakend]) => {
+      expect(parseBreakend(breakend)).toEqual(parsedBreakend)
+    })
+  })
+
+  it('parses assembly-contig mate positions (VCFv4.5 section 5.4.1)', () => {
+    // mate position can be a contig in the assembly file: <ctg1>:pos
+    const contigsAndParsed = [
+      [
+        'C[<ctg1>:1[',
+        {
+          MatePosition: '<ctg1>:1',
+          Join: 'right',
+          Replacement: 'C',
+          MateDirection: 'right',
+        },
+      ],
+      [
+        ']<ctg1>:329]A',
+        {
+          MatePosition: '<ctg1>:329',
+          Join: 'left',
+          Replacement: 'A',
+          MateDirection: 'left',
+        },
+      ],
+    ] as [string, Breakend][]
+    contigsAndParsed.forEach(([breakend, parsedBreakend]) => {
+      expect(parseBreakend(breakend)).toEqual(parsedBreakend)
+    })
+  })
+
+  it('parses single breakends (VCFv4.5 section 5.4.9)', () => {
+    expect(parseBreakend('G.')).toEqual({
+      Join: 'right',
+      SingleBreakend: true,
+      Replacement: 'G',
+    })
+    expect(parseBreakend('.A')).toEqual({
+      Join: 'left',
+      SingleBreakend: true,
+      Replacement: 'A',
+    })
+  })
+
   it('throws on invalid breakend', () => {
     expect(() => parseBreakend('[13:123457[')).toThrow(/Invalid breakend/)
   })

--- a/test/parseGenotypesOnly-edge-cases.test.ts
+++ b/test/parseGenotypesOnly-edge-cases.test.ts
@@ -448,3 +448,21 @@ test('alternating ploidy pattern', () => {
     S8: '0/1',
   })
 })
+
+test('field containing GT as substring is not mistaken for GT (real GT first)', () => {
+  const result = parseGenotypesOnly('GT:PGT:PID', '0/1:0|1:1\t1/1:1|0:2', [
+    'S1',
+    'S2',
+  ])
+  expect(result).toEqual({ S1: '0/1', S2: '1/1' })
+})
+
+test('field containing GT as substring is not mistaken for GT (real GT later)', () => {
+  const result = parseGenotypesOnly('AGT:GT', 'foo:0/1\tbar:1/1', ['S1', 'S2'])
+  expect(result).toEqual({ S1: '0/1', S2: '1/1' })
+})
+
+test('no real GT field, only PGT - returns empty', () => {
+  const result = parseGenotypesOnly('PGT:PID', '0|1:1\t1|0:2', ['S1', 'S2'])
+  expect(result).toEqual({})
+})


### PR DESCRIPTION
uncommon issue but ensures it is an exact match to GT and not PGT (which gatk outputs)